### PR TITLE
Debugging

### DIFF
--- a/sensor_hub/lib/sensor_hub/application.ex
+++ b/sensor_hub/lib/sensor_hub/application.ex
@@ -47,8 +47,8 @@ defmodule SensorHub.Application do
   end
 
   defp sensors do
-    []
-    # [Sensor.new(BME680), Sensor.new(Veml7700), Sensor.new(SGP40)]
+    # []
+    [Sensor.new(BME680), Sensor.new(Veml7700), Sensor.new(SGP40)]
   end
 
   defp api_url() do

--- a/sensor_hub/lib/sensor_hub/sensor.ex
+++ b/sensor_hub/lib/sensor_hub/sensor.ex
@@ -25,7 +25,7 @@ defmodule SensorHub.Sensor do
   def fields(Veml7700), do: [:light_lumens]
 
   def read_fn(SGP40) do
-    fn -> Process.whereis(:sgp40) |> SGP40.measure() end
+    fn -> Process.whereis(:SGP40) |> SGP40.measure() end
   end
 
   def read_fn(Veml7700), do: fn -> Veml7700.get_measurement() end
@@ -69,7 +69,7 @@ defmodule SensorHub.Sensor do
 
   def convert_fn(Veml7700) do
     fn reading ->
-      %{light_lumens: reading}
+      %{lumens: reading}
     end
   end
 

--- a/tracker/lib/tracker/sensors/data.ex
+++ b/tracker/lib/tracker/sensors/data.ex
@@ -35,7 +35,7 @@ defmodule Tracker.Sensors.Data do
 
     data
     |> cast(attrs, @allowed_fields)
-    |> validate_required(@allowed_fields)
     |> put_change(:timestamp, timestamp)
+    |> validate_required(@allowed_fields)
   end
 end

--- a/tracker/lib/tracker_web/controllers/data_controller.ex
+++ b/tracker/lib/tracker_web/controllers/data_controller.ex
@@ -12,8 +12,6 @@ defmodule TrackerWeb.DataController do
 
   """
   def create(conn, params) do
-    IO.inspect(params)
-
     case(SensorData.create_entry(params)) do
       {:ok, data} ->
         Logger.debug("Success: done a data")


### PR DESCRIPTION
Data being received from the device to "server" (my machine) but I was seeing this.

```shell
%{}
[warning] Fail: didn't make a data: #Ecto.Changeset<action: :insert, changes: %{timestamp: ~N[2025-08-12 21:11:09]}, errors: [timestamp: {"can't be blank", [validation: :required]}, altitude_m: {"can't be blank", [validation: :required]}, pressure_pa: {"can't be blank", [validation: :required]}, temperature_c: {"can't be blank", [validation: :required]}, humidity_rh: {"can't be blank", [validation: :required]}, dew_point_c: {"can't be blank", [validation: :required]}, gas_resistance_ohms: {"can't be blank", [validation: :required]}, voc_index: {"can't be blank", [validation: :required]}, lumens: {"can't be blank", [validation: :required]}], data: #Tracker.Sensors.Data<>, valid?: false, ...>
```

Seemingly no

## Sensors

- [x] Is it plugged in? 

I went through all the code, made on adjustment on a codebase and rebuilt the firmware and pushed it up to the nerves device.

yes, all sensors confirmed as capable of taking measurements by shelling into the device (ssh hub.local) and speaking directly with the process to get measurement. Here's the BME680 sensors (_uses [BMP280 library](https://github.com/elixir-sensors/bmp280) - name-mismatch could have been an issue before firmware rebuild_)

```elixir
Process.whereis(:BME680) |> BMP280.measure()
{:ok,
 %BMP280.Measurement{
   temperature_c: 25.7148043252344,
   pressure_pa: 101355.96131124489,
   altitude_m: -113.76300175716008,
   humidity_rh: 57.833497274563314,
   dew_point_c: 16.787913608636288,
   gas_resistance_ohms: 52270.37181191309,
   timestamp_ms: 521563
 }}
```

- [x] Is it turned on?

Yes, also confirmed via ssh.

```elixir
light = SensorHub.Sensor.new(Veml7700)
%SensorHub.Sensor{
  name: Veml7700,
  fields: [:light_lumens],
  read: #Function<4.93234991/0 in SensorHub.Sensor.read_fn/1>,
  convert: #Function<1.93234991/1 in SensorHub.Sensor.convert_fn/1>
}
SensorHub.Sensor.measure(light)
%{lumens: 4.3776}
```


- [x] Have you checked? 

yes. I'm satisfied that the sensors are functioning and capable of repor

- [x] Check again.

yes

## Supervisors
- [x] Is it plugged in?
- [x] Is it turned on?
- [x] Have you checked?
- [x] Check again.

verified above by ssh.

```elixir
Supervisor.which_children(SensorHub.Supervisor)
[
  {Publisher, #PID<0.1368.0>, :worker, [Publisher]},
  {TrackerClient, #PID<0.1363.0>, :worker, [Finch]},
  {Veml7700, #PID<0.1360.0>, :worker, [Veml7700]},
  {BMP280, #PID<0.1359.0>, :worker, [BMP280]},
  {SGP40, #PID<0.1354.0>, :worker, [SGP40]}
]```

Sensors present, Publisher present and tracker client present.

I'm going to say Supervisors and GenServers are doing what they are supposed to.


## Ecto

- [x] Is it plugged in?

🎉 🎉 🎉  Movement. 🎉 🎉 🎉  

The above changeset errors where the full changeset was empty has changed. Looks like the firmware update straightened something out and now I am seeing data in the changeset. 

However, I had to rebuild the firmware again to get the VEML7700 sensor to send `lumens` and not `light_lumens`. That unblocked one of the two changset errors.

- [x] Is it turned on?

There was some issues around timestamp not being set, but that was down to `put_change/3` being placed AFTER the `validate_required/3` function. Rookie error. Once that was fixed...

```shell
[info] Sent 201 in 2ms
[info] POST /api/v1/sensor/data
[debug] Processing with TrackerWeb.DataController.create/2
  Parameters: %{"altitude_m" => -113.10377176768466, "dew_point_c" => 16.66574177591562, "gas_resistance_ohms" => 54260.97522982572, "humidity_rh" => 57.79010907682903, "lumens" => 4.3776, "pressure_pa" => 101348.06117747129, "temperature_c" => 25.59673873968768, "voc_index" => 102}
  Pipelines: [:api]
[debug] QUERY OK source="sensor_data" db=1.6ms idle=1165.0ms
INSERT INTO "sensor_data" ("timestamp","altitude_m","dew_point_c","gas_resistance_ohms","humidity_rh","lumens","pressure_pa","temperature_c","voc_index") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) [~N[2025-08-13 19:25:31], Decimal.new("-113.10377176768466"), Decimal.new("16.66574177591562"), Decimal.new("54260.97522982572"), Decimal.new("57.79010907682903"), Decimal.new("4.3776"), Decimal.new("101348.06117747129"), Decimal.new("25.59673873968768"), Decimal.new("102")]
```

- [x] Have you checked?
- [x] Check again.

## Summary

I should give myself more credit than I do.  It was a silly error on a pattern match which created bad firmware and hence reporting wasn't firing at all which meant - empty changesets. Once that was fixed, it was down to mismatched `lumens` vs `light_lumens` and moving `put_change/3` up in the changeset pipeline.

Case closed.

